### PR TITLE
docs(readme): Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ El proyecto incluye configuración lista para producción usando Docker.
     docker-compose up -d --build
     ```
 
-    Esto iniciará la aplicación en el puerto **3001** en modo producción optimizado (Standalone).
+    Esto iniciará la aplicación en el puerto **3000** en modo producción optimizado (Standalone).
 
 3.  **Ver logs:**
     ```bash


### PR DESCRIPTION
This pull request updates the documentation to correct the port number used by the application in production mode.

- Updated the `README.md` to indicate that the application runs on port `3000` (instead of `3001`) when started in production mode using Docker.